### PR TITLE
Returns with date v2

### DIFF
--- a/pyalgotrade/stratanalyzer/returns.py
+++ b/pyalgotrade/stratanalyzer/returns.py
@@ -208,8 +208,8 @@ class Returns(stratanalyzer.StrategyAnalyzer):
         analyzer.getEvent().subscribe(self.__onReturns)
 
     def __onReturns(self, dateTime, returnsAnalyzerBase):
-        self.__netReturns.append(returnsAnalyzerBase.getNetReturn())
-        self.__cumReturns.append(returnsAnalyzerBase.getCumulativeReturn())
+        self.__netReturns.appendWithDateTime(dateTime, returnsAnalyzerBase.getNetReturn())
+        self.__cumReturns.appendWithDateTime(dateTime, returnsAnalyzerBase.getCumulativeReturn())
 
     def getReturns(self):
         """Returns a :class:`pyalgotrade.dataseries.DataSeries` with the returns for each bar."""

--- a/testcases/returns_analyzer_test.py
+++ b/testcases/returns_analyzer_test.py
@@ -451,3 +451,5 @@ class AnalyzerTestCase(common.TestCase):
         strat.run()
         self.assertEqual(stratAnalyzer.getReturns()[0], 0)
         self.assertEqual(stratAnalyzer.getReturns()[1], (32.00 - 25.25) / 1000)
+        self.assertIsNotNone(stratAnalyzer.getReturns().getDateTimes()[0])
+        self.assertIsNotNone(stratAnalyzer.getCumulativeReturns().getDateTimes()[0])


### PR DESCRIPTION
Hi,
my goal is to get a table of returns working similar to to this one
http://www.trendfollowing.com/images/mulv.jpg

It appeared that I have no access to dates anywhere, so I looked into what your class is doing and amended it a bit. The returns tests all pass, but I have 10 failing tests overall (some related to twitter and talib that don't surprise me).

A side note: Is 
```
    returnsAnalyzer.getCumulativeReturns().setMaxLen(5000)
```
the right way to go about increasing the returns length before running a strategy? Can I set -1 or so for infinite length?

Best regards,
Matthias