### PR TITLE
Make Event simpler; fix a latent bug

### DIFF
--- a/pyalgotrade/observer.py
+++ b/pyalgotrade/observer.py
@@ -25,32 +25,29 @@ from pyalgotrade import dispatchprio
 
 class Event(object):
     def __init__(self):
-        self.__handlers = []
-        self.__toSubscribe = []
-        self.__toUnsubscribe = []
+        self.__handlers = set()
+        self.__toSubscribe = set()
+        self.__toUnsubscribe = set()
         self.__emitting = False
 
     def __applyChanges(self):
-        if len(self.__toSubscribe):
-            for handler in self.__toSubscribe:
-                if handler not in self.__handlers:
-                    self.__handlers.append(handler)
-            self.__toSubscribe = []
+        if self.__toSubscribe:
+            self.__handlers.intersection_update(self.__toSubscribe)
+            self.__toSubscribe = set()
 
-        if len(self.__toUnsubscribe):
-            for handler in self.__toUnsubscribe:
-                self.__handlers.remove(handler)
-            self.__toUnsubscribe = []
+        if self.__toUnsubscribe:
+            self.__handlers.difference_update(self.__toUnsubscribe)
+            self.__toUnsubscribe = set()
 
     def subscribe(self, handler):
         if self.__emitting:
-            self.__toSubscribe.append(handler)
-        elif handler not in self.__handlers:
-            self.__handlers.append(handler)
+            self.__toSubscribe.add(handler)
+        else:
+            self.__handlers.add(handler)
 
     def unsubscribe(self, handler):
         if self.__emitting:
-            self.__toUnsubscribe.append(handler)
+            self.__toUnsubscribe.add(handler)
         else:
             self.__handlers.remove(handler)
 

--- a/pyalgotrade/observer.py
+++ b/pyalgotrade/observer.py
@@ -26,28 +26,23 @@ from pyalgotrade import dispatchprio
 class Event(object):
     def __init__(self):
         self.__handlers = set()
-        self.__toSubscribe = set()
-        self.__toUnsubscribe = set()
+        self.__changes = []
         self.__emitting = False
 
     def __applyChanges(self):
-        if self.__toSubscribe:
-            self.__handlers.intersection_update(self.__toSubscribe)
-            self.__toSubscribe = set()
-
-        if self.__toUnsubscribe:
-            self.__handlers.difference_update(self.__toUnsubscribe)
-            self.__toUnsubscribe = set()
+        if self.__changes:
+            for verb, arg in self.__changes:
+                verb(arg)
 
     def subscribe(self, handler):
         if self.__emitting:
-            self.__toSubscribe.add(handler)
+            self.__changes.append((self.__handlers.add, handler))
         else:
             self.__handlers.add(handler)
 
     def unsubscribe(self, handler):
         if self.__emitting:
-            self.__toUnsubscribe.add(handler)
+            self.__changes.append((self.__handlers.difference_update, {handler}))
         else:
             self.__handlers.remove(handler)
 


### PR DESCRIPTION
First I switched Event to using sets because it made it simpler.

Then I fixed a latent bug:  If, while it was emitting, you were to first unsubscribe and then resubscribe,  you would end up unsubscribed.