### PR TITLE
Handle error on quandl empty/malformed data

### DIFF
--- a/pyalgotrade/tools/quandl.py
+++ b/pyalgotrade/tools/quandl.py
@@ -160,7 +160,14 @@ def build_feed(sourceCode, tableCodes, fromYear, toYear, storage, frequency=bar.
                         continue
                     else:
                         raise e
-            ret.addBarsFromCSV(tableCode, fileName, skipMalformedBars=skipMalformedBars)
+            try:
+                ret.addBarsFromCSV(tableCode, fileName, skipMalformedBars=skipMalformedBars)
+            except Exception as e:
+                if skipErrors:
+                    logger.error(str(e))
+                    continue
+                else:
+                    raise e
     return ret
 
 


### PR DESCRIPTION
Sometimes quandl returns empty or malformed csv files when the ticker you are trying to download does not exist on the specified time. This pull request allows to skip these errors when passing the skipErrors parameter to the handler. In this case the bars we are trying to add are just ignored.
