### PR TITLE
docs: fix simple typo, becuase -> because

### DIFF
--- a/pyalgotrade/broker/fillstrategy.py
+++ b/pyalgotrade/broker/fillstrategy.py
@@ -261,7 +261,7 @@ class DefaultStrategy(FillStrategy):
     def onOrderFilled(self, broker_, order):
         # Update the volume left.
         if self.__volumeLimit is not None:
-            # We round the volume left here becuase it was not rounded when it was initialized.
+            # We round the volume left here because it was not rounded when it was initialized.
             volumeLeft = order.getInstrumentTraits().roundQuantity(self.__volumeLeft[order.getInstrument()])
             fillQuantity = order.getExecutionInfo().getQuantity()
             assert volumeLeft >= fillQuantity, \

--- a/pyalgotrade/stratanalyzer/sharpe.py
+++ b/pyalgotrade/stratanalyzer/sharpe.py
@@ -67,7 +67,7 @@ def sharpe_ratio_2(returns, riskFreeRate, firstDateTime, lastDateTime, annualize
     volatility = stats.stddev(returns, 1)
 
     if volatility != 0:
-        # We use 365 instead of 252 becuase we wan't the diff from 1/1/xxxx to 12/31/xxxx to be 1 year.
+        # We use 365 instead of 252 because we wan't the diff from 1/1/xxxx to 12/31/xxxx to be 1 year.
         yearsTraded = days_traded(firstDateTime, lastDateTime) / 365.0
 
         riskFreeRateForPeriod = riskFreeRate * yearsTraded


### PR DESCRIPTION
There is a small typo in pyalgotrade/broker/fillstrategy.py, pyalgotrade/stratanalyzer/sharpe.py.

Should read `because` rather than `becuase`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md